### PR TITLE
test: add frontend unit tests

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "axios": "^1.9.0",
@@ -17,6 +18,8 @@
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^5.2.3",
-    "vite": "^6.3.5"
+    "vite": "^6.3.5",
+    "@vue/test-utils": "^2.4.3",
+    "vitest": "^1.6.0"
   }
 }

--- a/frontend/src/components/__tests__/OrderButton.spec.js
+++ b/frontend/src/components/__tests__/OrderButton.spec.js
@@ -1,0 +1,10 @@
+import { mount } from '@vue/test-utils'
+import OrderButton from '../OrderButton.vue'
+
+describe('OrderButton', () => {
+  it('emits order event on click', async () => {
+    const wrapper = mount(OrderButton)
+    await wrapper.find('button').trigger('click')
+    expect(wrapper.emitted()).toHaveProperty('order')
+  })
+})

--- a/frontend/src/components/__tests__/ProgressBar.spec.js
+++ b/frontend/src/components/__tests__/ProgressBar.spec.js
@@ -1,0 +1,11 @@
+import { mount } from '@vue/test-utils'
+import ProgressBar from '../ProgressBar.vue'
+
+describe('ProgressBar', () => {
+  it('highlights the current step', () => {
+    const wrapper = mount(ProgressBar, { props: { currentStep: 2 } })
+    const activeSteps = wrapper.findAll('.progress-step.active')
+    expect(activeSteps).toHaveLength(1)
+    expect(activeSteps[0].find('.circle').text()).toBe('2')
+  })
+})

--- a/frontend/vitest.config.js
+++ b/frontend/vitest.config.js
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config'
+import vue from '@vitejs/plugin-vue'
+
+export default defineConfig({
+  plugins: [vue()],
+  test: {
+    globals: true,
+    environment: 'jsdom'
+  }
+})


### PR DESCRIPTION
## Summary
- add Vitest configuration for frontend
- cover OrderButton and ProgressBar components with unit tests

## Testing
- `npm test --prefix frontend` *(fails: vitest not found)*
- `npm install --prefix frontend --save-dev vitest @vue/test-utils --registry=https://registry.npmmirror.com` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ae7646bf84832ab3cbc9803ff4dc77